### PR TITLE
Only use offset for csd windows

### DIFF
--- a/gridlock.py
+++ b/gridlock.py
@@ -168,7 +168,7 @@ class GridLock(Gtk.Window):
         ctx.fill()
 
         ctx.set_source_rgba(*args.grid_color)
-        ctx.set_line_width(7)
+        ctx.set_line_width(args.grid_thickness)
         ctx.set_line_join(cairo.LINE_JOIN_ROUND)
 
         for i in range(1, self.cols):
@@ -297,7 +297,7 @@ arg_parser.add_argument('-g', '--grid',
     )
 arg_parser.add_argument('-c', '--grid-color',
     dest='grid_color', action='store',
-    help='grid color as "red,green,blue[,opacity]"',
+    help='grid color as "red,green,blue[,opacity], eg. 0,0,1.0 for blue"',
     )
 arg_parser.add_argument('-b', '--background-color', '--bg-color',
     dest='bg_color', action='store',
@@ -307,6 +307,11 @@ arg_parser.add_argument('-l', '--hilight-color', '--hi-color',
     dest='hi_color', action='store',
     help='hilight color as "red,green,blue[,opacity]"',
     )
+arg_parser.add_argument('-t', '--grid-thickness', 
+    dest='grid_thickness', action='store',
+    help='thickness of the lines of the grid lines in pixels'
+    )
+
 
 args = arg_parser.parse_args()
 
@@ -358,6 +363,11 @@ if args.hi_color is not None:
     args.hi_color = parse_color_spec(args.hi_color)
 else:
     args.hi_color = (1.0, 1.0, 1.0, .3)
+
+if args.grid_thickness is not None:
+    args.grid_thickness = int(args.grid_thickness)
+else:
+    args.grid_thickness = 7
 
 screen = Wnck.Screen.get_default()
 screen.force_update()

--- a/gridlock.py
+++ b/gridlock.py
@@ -371,8 +371,7 @@ if args.debug:
     print(f'          type = "{active_window.get_window_type()}"')
     print(f'      geometry = {active_window.get_geometry()}')
     print(f'clientgeometry = {active_window.get_client_window_geometry()}')
-    print(f'{active_window.get_client_window_geometry() == active_window.get_geometry()}')
-    print(f'          role = {active_window.get_role()}')
+    print(f'clientgeometry equals window geometry = {active_window.get_client_window_geometry() == active_window.get_geometry()}')
 
 # windows that have CSD enabled actually report that their client_window_geometry is the same as the full window_geometry, so only add the offset to those windows
 if active_window.get_client_window_geometry() == active_window.get_geometry():


### PR DESCRIPTION
I've noticed that the offset help with negating the shadows done GLX.
2 fixes:
1. only use them for CSD windows (so if client_geometry == window geometry)
2. make sure to add double of the absolute value of the offset to both the width or height of the window