### PR TITLE
Make sure the grid window stays on top

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-*
-!gridlock.py
-!README.md
-!screenshot.png
-!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*
+!gridlock.py
+!README.md
+!screenshot.png
+!.gitignore

--- a/gridlock.py
+++ b/gridlock.py
@@ -92,6 +92,7 @@ class GridLock(Gtk.Window):
             #
             self.maximize()
             self.set_decorated(False)
+            self.set_keep_above(True)
 
         screen = self.get_screen()
         visual = screen.get_rgba_visual()


### PR DESCRIPTION
In some edge cases the gtk.window with the grid gets drawn below all my other windows (this seems to be only in the case of the non full-screen window. So I added a call to the window to make it on top.
Also i added a .gitignore file to basically ignore everything except 4 files that are in the repo already (this is because i have some test scripts and log files to help improve the code that i otherwise would accidently push in there...)