### PR TITLE
bug: gridlock can not resize windows that are maximized

### DIFF
--- a/gridlock.py
+++ b/gridlock.py
@@ -77,7 +77,6 @@ class GridLock(Gtk.Window):
 
         self.active_window = active_window
         self.window_was_maximized = active_window.is_maximized()
-        print(f'window was maximized: {self.window_was_maximized}')
         self.cols = cols
         self.rows = rows
         self.drag = False

--- a/gridlock.py
+++ b/gridlock.py
@@ -76,6 +76,8 @@ class GridLock(Gtk.Window):
         super().__init__(title='Gridlock')
 
         self.active_window = active_window
+        self.window_was_maximized = active_window.is_maximized()
+        print(f'window was maximized: {self.window_was_maximized}')
         self.cols = cols
         self.rows = rows
         self.drag = False
@@ -227,6 +229,11 @@ class GridLock(Gtk.Window):
                 print(f'  grid geometry = {grid_width}x{grid_height}+{grid_x}+{grid_y}')
                 print(f'  offset = {args.offset}')
                 print(f'  translated geometry = {width}x{height}+{new_x}+{new_y}')
+
+            # if the window was maximized we need to unmaximize it before we try to resize it, otherwise the resize operation fails
+            if self.window_was_maximized:
+                print('unmaximizing before resizing!!!')
+                self.active_window.unmaximize()
 
             self.active_window.set_geometry(
                 args.gravity,


### PR DESCRIPTION
This commit unmaximizes the window before the resize operation. 